### PR TITLE
TR-47 Complete CI-CD

### DIFF
--- a/.github/workflows/merge_action.yml
+++ b/.github/workflows/merge_action.yml
@@ -1,4 +1,4 @@
-name: On merge action
+name: Merge tests
 
 on:
   push:
@@ -10,45 +10,51 @@ env:
   POSTGRES_USER: ${{ secrets.POSTGRES_DB_USERNAME }}
   POSTGRES_PASSWORD: ${{ secrets.POSTGRES_DB_PASSWORD }}
   POSTGRES_VERSION: ${{ vars.POSTGRES_VERSION }}
-  JAVA_VERSION: ${{ vars.JAVA_VERSION }}
+  POSTGRES_DB: ${{ vars.POSTGRES_DB }}
+
+  OPENJDK_VERSION: ${{ vars.JAVA_VERSION }}
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:${{ vars.POSTGRES_VERSION }}
-        env:
-          POSTGRES_USER: '${{ vars.POSTGRES_USER }}'
-          POSTGRES_PASSWORD: '${{ vars.POSTGRES_PASSWORD }}'
-          POSTGRES_DB: '${{ vars.POSTGRES_DB }}'
-        ports:
-          - "5433:5432"
     steps:
+      - name: Start test-DB (PostgreSQL ${{ vars.POSTGRES_VERSION }})
+        run: |
+          docker run --name postgres -d -p 5433:5432 \
+          -e POSTGRES_USER=$POSTGRES_USER \
+          -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
+          -e POSTGRES_DB=$POSTGRES_DB \
+          --health-cmd pg_isready \
+          --health-interval 10s \
+          --health-timeout 5s \
+          --health-retries 5 \
+          postgres
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ vars.JAVA_VERSION }}
         uses: actions/setup-java@v3
         with:
           java-version: '${{ vars.JAVA_VERSION }}'
           distribution: 'oracle'
+          cache: maven
       - name: Run tests with Maven
-        run: mvn -B -Dspring.profiles.active=local clean test
-  build:
-    needs: "test"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK ${{ vars.JAVA_VERSION }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: '${{ vars.JAVA_VERSION }}'
-          distribution: 'oracle'
+        run: mvn --quiet -Denv=local clean test
       - name: Build with Maven
-        run: mvn -B -Dmaven.test.skip -Dspring.profiles.active=local package
+        run: mvn --quiet -Dmaven.test.skip -Denv=local package
   deploy:
-    needs: "build"
+    needs: test
     runs-on: ubuntu-latest
     steps:
+      - name: Start build-DB
+        run: |
+          docker run --name postgres -d -p 5433:5432 \
+          -e POSTGRES_USER=$POSTGRES_USER \
+          -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
+          -e POSTGRES_DB=$POSTGRES_DB \
+          --health-cmd pg_isready \
+          --health-interval 10s \
+          --health-timeout 5s \
+          --health-retries 5 \
+          postgres
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ vars.JAVA_VERSION }}
         uses: actions/setup-java@v3
@@ -57,30 +63,28 @@ jobs:
           distribution: 'oracle'
           cache: maven
       - name: Build with Maven
-        run: mvn -B -Dmaven.test.skip -Dspring.profiles.active=local package
+        run: mvn --quiet -Dmaven.test.skip -Denv=local package
       - name: Docker login
         run: echo "$PASSWORD" | docker login -u "$USER" --password-stdin
         env:
           USER: ${{ secrets.DOCKER_USERNAME }}
           PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Update date info
-        run: echo TAG=$(date --iso-8601=seconds) | tr ':' . | cut -c -23 > .env
       - name: Docker compose build
+        run: TAG=_ docker compose build --no-cache
+      - name: Docker compose push by date
         run: |
-          POSTGRES_NAME=${{ vars.POSTGRES_DB }} \
+          POSTGRES_DB=${{ vars.POSTGRES_DB }} \
           POSTGRES_USER=$POSTGRES_USER \
           POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
           POSTGRES_VERSION=$POSTGRES_VERSION \
           OPENJDK_VERSION=$JAVA_VERSION \
-          docker compose build --no-cache
-      - name: Docker compose push by date
-        run: docker compose push
+          TAG=B-$(date +'%Y-%m-%d') \
+          docker compose build --push
       - name: Docker compose push latest
         run: |
-          echo TAG=latest > .env &&
-          POSTGRES_NAME=${{ vars.POSTGRES_DB }} \
+          POSTGRES_DB=${{ vars.POSTGRES_DB }} \
           POSTGRES_USER=$POSTGRES_USER \
           POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
           POSTGRES_VERSION=$POSTGRES_VERSION \
           OPENJDK_VERSION=$JAVA_VERSION \
-          docker compose build --push --no-cache
+          TAG=B-latest docker compose build --push

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -1,0 +1,24 @@
+name: Deploy
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH connect & deploy
+        uses: cross-the-world/ssh-scp-ssh-pipelines@latest
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          user: ${{ secrets.SSH_USER }}
+          pass: ${{ secrets.SSH_PASSWORD }}
+          connect_timeout: 10s
+          first_ssh: |
+            cd ~/server
+            sed '/BACKEND_TAG/d' .env -i
+            echo "BACKEND_TAG=B-latest" >> .env
+            docker compose down
+            docker compose up -d
+            docker image prune --all --force

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -1,9 +1,8 @@
-name: On pull request action
+name: Pull request tests
 
 on:
   pull_request:
-    types:
-      - opened
+    types: [opened, reopened, edited]
     branches:
       - main
   workflow_dispatch:
@@ -11,33 +10,27 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:${{ vars.POSTGRES_VERSION }}
+    steps:
+      - name: Start test-DB (PostgreSQL ${{ vars.POSTGRES_VERSION }})
         env:
           POSTGRES_USER: '${{ secrets.POSTGRES_DB_USERNAME }}'
           POSTGRES_PASSWORD: '${{ secrets.POSTGRES_DB_PASSWORD }}'
           POSTGRES_DB: '${{ vars.POSTGRES_DB }}'
-        ports:
-          - "5433:5432"
-    steps:
+        run: |
+          docker run --name postgres -d -p 5433:5432 \
+          -e POSTGRES_USER=$POSTGRES_USER \
+          -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
+          -e POSTGRES_DB=$POSTGRES_DB \
+          --health-cmd pg_isready \
+          --health-interval 10s \
+          --health-timeout 5s \
+          --health-retries 5 \
+          postgres
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ vars.JAVA_VERSION }}
         uses: actions/setup-java@v3
         with:
           java-version: '${{ vars.JAVA_VERSION }}'
           distribution: 'oracle'
-      - name: Run tests with Maven
-        run: mvn -B -Dspring.profiles.active=local clean test
-  build:
-    needs: "test"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK ${{ vars.JAVA_VERSION }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: '${{ vars.JAVA_VERSION }}'
-          distribution: 'oracle'
-      - name: Build with Maven
-        run: mvn -B -Dmaven.test.skip -Dspring.profiles.active=local package
+      - name: Run tests and build with Maven
+        run: mvn --quiet -Denv=local clean test package

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,31 @@
-version: "3.9"
+version: "3"
 services:
   postgres:
     container_name: techradar-db
     image: postgres:${POSTGRES_VERSION:-15.2}
     environment:
-      POSTGRES_DB: ${POSTGRES_NAME:-tech_radar}
+      POSTGRES_DB: ${POSTGRES_DB:-tech_radar}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
-      - "5433:5432"
+      - 5433:5432
     networks:
       - radar
   techradar-api:
     container_name: techradar-api
-    image: techradarapi/techradar-api:${TAG:-latest}
+    image: techradarapi/techradar-api:${TAG:-B-latest}
     build:
       context: .
       dockerfile_inline: |
         FROM openjdk:${OPENJDK_VERSION:-20}
-        EXPOSE 8080
         COPY target/*.jar app.jar
-        ENTRYPOINT ["java","-jar","app.jar","– spring.profiles.active=local"]
+        ENTRYPOINT ["java","-jar","app.jar"]
     ports:
-      - "8080:8080"
+      - 8080:8080
     depends_on:
-      - "postgres"
+      - postgres
     networks:
       - radar
 networks:
   radar:
-    name: radar
     driver: bridge

--- a/src/main/resources/changelog/master.xml
+++ b/src/main/resources/changelog/master.xml
@@ -4,6 +4,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <include file="changelog\v001\change_db.xml"/>
+    <include file="v001/change_db.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/liquibase.yml
+++ b/src/main/resources/liquibase.yml
@@ -1,5 +1,5 @@
 driver: org.postgresql.Driver
-url: jdbc:postgresql://localhost:5433/tech_radar
+url: jdbc:postgresql://postgres:5432/tech_radar
 username: postgres
 password: postgres
 changeLogFile: src/main/resources/changelog/master.xml


### PR DESCRIPTION
Доработка 2 старых action-ов + новый, срабатывающий на создание новой версии и ведущий к отправке последнего образа на сервер.

Названия опубликованных на Hub-е docker-образов:
`techradarapi/techradar-api:B-2023-06-01` - это "для истории"
`techradarapi/techradar-api:B-latest` - это перезаписываемый, чтобы использовать последнюю стабильную версию в скриптах.

**Важная особенность:** если сделали мердж ветки и решили, что он достоин того, чтобы отправиться на сервер, подождите пока закончится выполнение action-а "Merge tests" и только после этого переходите к созданию версии. Проверить результат/выполнение action-a можно на вкладке "Actions" - должно быть вот так:
![Снимок экрана_2023-06-02_22-49-23](https://github.com/hhru-school/techradar/assets/53121671/886b0111-c062-425b-aa4e-c72f8de2cbd8)
Если вместо зелёной галочки стоит жёлтый кружочек, то процесс идёт - надо ждать. 
Если красный крестик, то всё очень плохо - docker-образ не удалось создать - надо смотреть логи action-a и/или писать, что "всё сломалось - иди чини".
