### PR TITLE
TR-72 - отображение статуса для каждого события лога

### DIFF
--- a/src/main/java/ru/hh/techradar/controller/BlipEventController.java
+++ b/src/main/java/ru/hh/techradar/controller/BlipEventController.java
@@ -16,6 +16,7 @@ import static ru.hh.techradar.controller.UtilService.getUsername;
 import ru.hh.techradar.dto.BlipEventDto;
 import ru.hh.techradar.mapper.BlipEventMapper;
 import ru.hh.techradar.mapper.BlipEventReadMapper;
+import ru.hh.techradar.mapper.BlipEventShortReadMapper;
 import ru.hh.techradar.service.BlipEventService;
 
 @Controller
@@ -24,11 +25,16 @@ public class BlipEventController {
   private final BlipEventMapper blipEventMapper;
   private final BlipEventService blipEventService;
   private final BlipEventReadMapper blipEventReadMapper;
+  private final BlipEventShortReadMapper blipEventShortReadMapper;
 
-  public BlipEventController(BlipEventMapper blipEventMapper, BlipEventService blipEventService, BlipEventReadMapper blipEventReadMapper) {
+  public BlipEventController(BlipEventMapper blipEventMapper,
+      BlipEventService blipEventService,
+      BlipEventReadMapper blipEventReadMapper,
+      BlipEventShortReadMapper blipEventShortReadMapper) {
     this.blipEventMapper = blipEventMapper;
     this.blipEventService = blipEventService;
     this.blipEventReadMapper = blipEventReadMapper;
+    this.blipEventShortReadMapper = blipEventShortReadMapper;
   }
 
   @POST
@@ -63,8 +69,8 @@ public class BlipEventController {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/radar-log")
-  public Response findAllBlipsByBlipEventId(@QueryParam("blip-event-id") Long blipEventId) {
-    return Response.ok(blipEventReadMapper.toDtos(blipEventService.findAllBlipsByBlipEventId(blipEventId)))
+  public Response findAllBlipsByRadarVersion(@QueryParam("radar-version-id") Long radarVersionId) {
+    return Response.ok(blipEventReadMapper.toDtos(blipEventService.findAllBlipsByRadarVersionId(radarVersionId)))
         .build();
   }
 
@@ -78,7 +84,7 @@ public class BlipEventController {
       BlipEventDto dto
   ) {
     dto.setId(blipEventId);
-    return Response.ok(blipEventMapper.toDto(blipEventService.update(dto, isMove)))
+    return Response.ok(blipEventShortReadMapper.toDto(blipEventService.update(dto, isMove)))
         .build();
   }
 

--- a/src/main/java/ru/hh/techradar/controller/CompanyController.java
+++ b/src/main/java/ru/hh/techradar/controller/CompanyController.java
@@ -73,7 +73,7 @@ public class CompanyController {
   @Produces(MediaType.APPLICATION_JSON)
   public Response findUsersById(@PathParam("id") Long id) {
     return Response
-        .ok(userMapper.toDtos(companyService.findById(id).getUsers()))
+        .ok(userMapper.toDtos(companyService.findUsersByCompanyId(id)))
         .build();
   }
 

--- a/src/main/java/ru/hh/techradar/controller/UserController.java
+++ b/src/main/java/ru/hh/techradar/controller/UserController.java
@@ -116,10 +116,10 @@ public class UserController {
   @DELETE
   @Path("/{username}/companies/{company-id}")
   public Response disjointUserAndCompany(
-      @PathParam("username") String userName,
+      @PathParam("username") String username,
       @PathParam("company-id") Long companyId
   ) {
-    userService.disjointUserAndCompany(userName, companyId);
+    userService.disjointUserAndCompany(username, companyId);
     return Response
         .status(Response.Status.NO_CONTENT)
         .build();

--- a/src/main/java/ru/hh/techradar/dto/BlipDto.java
+++ b/src/main/java/ru/hh/techradar/dto/BlipDto.java
@@ -17,7 +17,7 @@ public class BlipDto {
   public BlipDto() {
   }
 
-  public BlipDto(Long id, String name, String description, BlipEventDto blipEventDto) {
+  public BlipDto(Long id, String name, String description) {
     this.id = id;
     this.name = name;
     this.description = description;

--- a/src/main/java/ru/hh/techradar/dto/BlipEventReadDto.java
+++ b/src/main/java/ru/hh/techradar/dto/BlipEventReadDto.java
@@ -9,6 +9,8 @@ public class BlipEventReadDto {
   private BlipDto blip;
   private QuadrantDto quadrant;
   private RingDto ring;
+  private String drawInfo;
+  private String radarVersion;
   private UserDto author;
   private Instant creationTime;
   private Instant lastChangeTime;
@@ -23,6 +25,8 @@ public class BlipEventReadDto {
       BlipDto blip,
       QuadrantDto quadrant,
       RingDto ring,
+      String drawInfo,
+      String radarVersion,
       UserDto author,
       Instant creationTime,
       Instant lastChangeTime) {
@@ -32,6 +36,8 @@ public class BlipEventReadDto {
     this.blip = blip;
     this.quadrant = quadrant;
     this.ring = ring;
+    this.drawInfo = drawInfo;
+    this.radarVersion = radarVersion;
     this.author = author;
     this.creationTime = creationTime;
     this.lastChangeTime = lastChangeTime;
@@ -91,6 +97,22 @@ public class BlipEventReadDto {
 
   public void setAuthor(UserDto author) {
     this.author = author;
+  }
+
+  public String getDrawInfo() {
+    return drawInfo;
+  }
+
+  public void setDrawInfo(String drawInfo) {
+    this.drawInfo = drawInfo;
+  }
+
+  public String getRadarVersion() {
+    return radarVersion;
+  }
+
+  public void setRadarVersion(String radarVersion) {
+    this.radarVersion = radarVersion;
   }
 
   public Instant getCreationTime() {

--- a/src/main/java/ru/hh/techradar/dto/BlipEventShortReadDto.java
+++ b/src/main/java/ru/hh/techradar/dto/BlipEventShortReadDto.java
@@ -1,32 +1,28 @@
 package ru.hh.techradar.dto;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.Instant;
 import java.util.Objects;
-import java.util.Optional;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class BlipEventDto {
+public class BlipEventShortReadDto {
   private Long id;
   private String comment;
   private Long parentId;
   private Long blipId;
-  private Optional<Long> quadrantId;
-  private Optional<Long> ringId;
+  private Long quadrantId;
+  private Long ringId;
   private Long authorId;
   private Long radarId;
   private Instant creationTime;
   private Instant lastChangeTime;
 
-  public BlipEventDto() {
+  public BlipEventShortReadDto() {
   }
 
-  public BlipEventDto(
+  public BlipEventShortReadDto(
       Long id,
       String comment,
       Long parentId, Long blipId,
-      Optional<Long> quadrantId,
-      Optional<Long> ringId,
+      Long quadrantId,
+      Long ringId,
       Long authorId,
       Long radarId,
       Instant creationTime,
@@ -68,20 +64,20 @@ public class BlipEventDto {
     this.blipId = blipId;
   }
 
-  public Optional<Long> getQuadrantId() {
+  public Long getQuadrantId() {
     return quadrantId;
   }
 
   public void setQuadrantId(Long quadrantId) {
-    this.quadrantId = Optional.ofNullable(quadrantId);
+    this.quadrantId = quadrantId;
   }
 
-  public Optional<Long> getRingId() {
+  public Long getRingId() {
     return ringId;
   }
 
   public void setRingId(Long ringId) {
-    this.ringId = Optional.ofNullable(ringId);
+    this.ringId = ringId;
   }
 
   public Long getAuthorId() {
@@ -129,19 +125,16 @@ public class BlipEventDto {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof BlipEventDto that)) {
+    if (!(o instanceof BlipEventShortReadDto that)) {
       return false;
     }
-    return Objects.equals(id, that.id) && Objects.equals(comment, that.comment) && Objects.equals(
-        parentId,
-        that.parentId
-    ) && Objects.equals(blipId, that.blipId) && Objects.equals(quadrantId, that.quadrantId) && Objects.equals(
+    return Objects.equals(comment, that.comment) && Objects.equals(parentId, that.parentId) && Objects.equals(
+        blipId,
+        that.blipId
+    ) && Objects.equals(quadrantId, that.quadrantId) && Objects.equals(
         ringId,
         that.ringId
-    ) && authorId.equals(that.authorId) && radarId.equals(that.radarId) && Objects.equals(
-        creationTime,
-        that.creationTime
-    ) && Objects.equals(lastChangeTime, that.lastChangeTime);
+    ) && authorId.equals(that.authorId) && radarId.equals(that.radarId);
   }
 
   @Override

--- a/src/main/java/ru/hh/techradar/dto/RadarVersionDto.java
+++ b/src/main/java/ru/hh/techradar/dto/RadarVersionDto.java
@@ -12,6 +12,7 @@ public class RadarVersionDto {
   private Long radarId;
   private Long blipEventId;
   private Long parentId;
+  private String parentName;
   private Integer level;
   private Boolean toggleAvailable;
   private Instant creationTime;
@@ -21,7 +22,7 @@ public class RadarVersionDto {
   }
 
   public RadarVersionDto(Long id, String name, Boolean release, Long radarId, Long blipEventId,
-      Long parentId, Integer level,
+      Long parentId, String parentName, Integer level,
       Boolean toggleAvailable, Instant creationTime, Instant lastChangeTime) {
     this.id = id;
     this.name = name;
@@ -29,6 +30,7 @@ public class RadarVersionDto {
     this.radarId = radarId;
     this.blipEventId = blipEventId;
     this.parentId = parentId;
+    this.parentName = parentName;
     this.level = level;
     this.toggleAvailable = toggleAvailable;
     this.creationTime = creationTime;
@@ -81,6 +83,14 @@ public class RadarVersionDto {
 
   public void setParentId(Long parentId) {
     this.parentId = parentId;
+  }
+
+  public String getParentName() {
+    return parentName;
+  }
+
+  public void setParentName(String parentName) {
+    this.parentName = parentName;
   }
 
   public Integer getLevel() {

--- a/src/main/java/ru/hh/techradar/entity/BlipEvent.java
+++ b/src/main/java/ru/hh/techradar/entity/BlipEvent.java
@@ -39,6 +39,12 @@ public class BlipEvent extends AuditableEntity<Long> {
   @JoinColumn(name = "radar_id", nullable = false)
   private Radar radar;
 
+  @Column(name = "draw_info")
+  private String drawInfo;
+
+  @Column(name = "radar_version")
+  private String radarVersion;
+
   public BlipEvent() {
   }
 
@@ -126,6 +132,22 @@ public class BlipEvent extends AuditableEntity<Long> {
 
   public void setRadar(Radar radar) {
     this.radar = radar;
+  }
+
+  public String getDrawInfo() {
+    return drawInfo;
+  }
+
+  public void setDrawInfo(String drawInfo) {
+    this.drawInfo = drawInfo;
+  }
+
+  public String getRadarVersion() {
+    return radarVersion;
+  }
+
+  public void setRadarVersion(String radarVersion) {
+    this.radarVersion = radarVersion;
   }
 
   @Override

--- a/src/main/java/ru/hh/techradar/mapper/BlipEventMapper.java
+++ b/src/main/java/ru/hh/techradar/mapper/BlipEventMapper.java
@@ -7,7 +7,6 @@ import ru.hh.techradar.entity.BlipEvent;
 
 @Component
 public class BlipEventMapper extends AbstractMapper<BlipEvent, BlipEventDto> {
-
   @Override
   public BlipEvent toEntity(BlipEventDto dto) {
     BlipEvent blipEvent = new BlipEvent();
@@ -26,19 +25,9 @@ public class BlipEventMapper extends AbstractMapper<BlipEvent, BlipEventDto> {
     Optional.ofNullable(entity.getQuadrant()).ifPresent(q -> blipEventDto.setQuadrantId(entity.getQuadrant().getId()));
     Optional.ofNullable(entity.getRing()).ifPresent(r -> blipEventDto.setRingId(entity.getRing().getId()));
     blipEventDto.setAuthorId(entity.getUser().getId());
+    blipEventDto.setRadarId(entity.getRadar().getId());
     blipEventDto.setCreationTime(entity.getCreationTime());
     blipEventDto.setLastChangeTime(entity.getLastChangeTime());
     return blipEventDto;
-  }
-
-  public BlipEvent toUpdate(BlipEvent target, BlipEvent source) {
-    Optional.ofNullable(source.getComment()).ifPresent(target::setComment);
-    Optional.ofNullable(source.getParentId()).ifPresent(target::setParentId);
-    Optional.ofNullable(source.getBlip()).ifPresent(target::setBlip);
-    Optional.ofNullable(source.getQuadrant()).ifPresent(target::setQuadrant);
-    Optional.ofNullable(source.getRing()).ifPresent(target::setRing);
-    Optional.ofNullable(source.getUser()).ifPresent(target::setUser);
-    Optional.ofNullable(source.getRadar()).ifPresent(target::setRadar);
-    return target;
   }
 }

--- a/src/main/java/ru/hh/techradar/mapper/BlipEventReadMapper.java
+++ b/src/main/java/ru/hh/techradar/mapper/BlipEventReadMapper.java
@@ -34,6 +34,8 @@ public class BlipEventReadMapper extends AbstractMapper<BlipEvent, BlipEventRead
     Optional.ofNullable(entity.getQuadrant()).ifPresent(q -> blipEventReadDto.setQuadrant(quadrantMapper.toDto(q)));
     Optional.ofNullable(entity.getRing()).ifPresent(r -> blipEventReadDto.setRing(ringMapper.toDto(r)));
     blipEventReadDto.setAuthor(userMapper.toDto(entity.getUser()));
+    blipEventReadDto.setDrawInfo(entity.getDrawInfo());
+    Optional.ofNullable(entity.getRadarVersion()).ifPresent(blipEventReadDto::setRadarVersion);
     blipEventReadDto.setCreationTime(entity.getCreationTime());
     blipEventReadDto.setLastChangeTime(entity.getLastChangeTime());
     return blipEventReadDto;

--- a/src/main/java/ru/hh/techradar/mapper/BlipEventShortReadMapper.java
+++ b/src/main/java/ru/hh/techradar/mapper/BlipEventShortReadMapper.java
@@ -1,0 +1,31 @@
+package ru.hh.techradar.mapper;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import ru.hh.techradar.dto.BlipEventShortReadDto;
+import ru.hh.techradar.entity.BlipEvent;
+
+@Component
+public class BlipEventShortReadMapper extends AbstractMapper<BlipEvent, BlipEventShortReadDto>{
+
+  @Override
+  public BlipEvent toEntity(BlipEventShortReadDto dto) {
+    return null;
+  }
+
+  @Override
+  public BlipEventShortReadDto toDto(BlipEvent entity) {
+    BlipEventShortReadDto blipEventShortReadDto = new BlipEventShortReadDto();
+    blipEventShortReadDto.setId(entity.getId());
+    blipEventShortReadDto.setComment(entity.getComment());
+    blipEventShortReadDto.setParentId(entity.getParentId());
+    Optional.ofNullable(entity.getBlip()).ifPresent(b -> blipEventShortReadDto.setBlipId(entity.getBlip().getId()));
+    Optional.ofNullable(entity.getQuadrant()).ifPresent(q -> blipEventShortReadDto.setQuadrantId(entity.getQuadrant().getId()));
+    Optional.ofNullable(entity.getRing()).ifPresent(r -> blipEventShortReadDto.setRingId(entity.getRing().getId()));
+    blipEventShortReadDto.setAuthorId(entity.getUser().getId());
+    blipEventShortReadDto.setRadarId(entity.getRadar().getId());
+    blipEventShortReadDto.setCreationTime(entity.getCreationTime());
+    blipEventShortReadDto.setLastChangeTime(entity.getLastChangeTime());
+    return blipEventShortReadDto;
+  }
+}

--- a/src/main/java/ru/hh/techradar/mapper/RadarVersionMapper.java
+++ b/src/main/java/ru/hh/techradar/mapper/RadarVersionMapper.java
@@ -27,6 +27,7 @@ public class RadarVersionMapper extends AbstractMapper<RadarVersion, RadarVersio
     radarVersionDto.setBlipEventId(entity.getBlipEvent().getId());
     radarVersionDto.setLevel(entity.getLevel());
     Optional.ofNullable(entity.getParent()).ifPresent(p -> radarVersionDto.setParentId(p.getId()));
+    Optional.ofNullable(entity.getParent()).ifPresent(p -> radarVersionDto.setParentName(p.getName()));
     radarVersionDto.setToggleAvailable(entity.getToggleAvailable());
     radarVersionDto.setCreationTime(entity.getCreationTime());
     radarVersionDto.setLastChangeTime(entity.getLastChangeTime());

--- a/src/main/java/ru/hh/techradar/repository/BlipEventRepository.java
+++ b/src/main/java/ru/hh/techradar/repository/BlipEventRepository.java
@@ -60,18 +60,54 @@ public class BlipEventRepository extends BaseRepositoryImpl<Long, BlipEvent> {
     Session session = sessionFactory.openSession();
     return session.createNativeQuery("""
                 WITH RECURSIVE r AS (
-                    SELECT blip_event_id, comment, parent_id, blip_id, quadrant_id, ring_id, author_id, radar_id, creation_time, last_change_time, 1 AS level
-                    FROM blip_event
-                    WHERE blip_event_id = :blipEventId
+                    SELECT be.blip_event_id, be.comment, be.parent_id, be.blip_id, be.quadrant_id, be.ring_id, be.author_id, be.radar_id,
+                           be.creation_time, be.last_change_time, 1 AS level,
+                           rv.radar_version_id AS radar_version_id,
+                           rv.name AS radar_version_name,
+                           rv.parent_id AS radar_version_parent_id,
+                           ri.position AS actual_ring_position
+                    FROM blip_event be
+                             LEFT JOIN radar_version rv ON rv.radar_version_id = (SELECT radar_version_id
+                                                                                 FROM radar_version
+                                                                                 WHERE blip_event_id = :blipEventId
+                                                                                 ORDER BY radar_version_id
+                                                                                 LIMIT 1)
+                             LEFT JOIN ring ri ON be.ring_id = ri.ring_id
+                             LEFT JOIN quadrant q ON be.quadrant_id = q.quadrant_id
+                    WHERE be.blip_event_id = :blipEventId
                     UNION
-                    SELECT e.blip_event_id, e.comment, e.parent_id,
-                           e.blip_id, e.quadrant_id, e.ring_id, e.author_id, e.radar_id, e.creation_time, e.last_change_time, r.level + 1 AS level
+                    SELECT e.blip_event_id, e.comment, e.parent_id, e.blip_id, e.quadrant_id, e.ring_id, e.author_id, e.radar_id,
+                           e.creation_time, e.last_change_time, r.level + 1 AS level,
+                           CASE WHEN rv.radar_version_id IS NULL THEN r.radar_version_id ELSE rv.radar_version_id END AS radar_version_id,
+                           CASE WHEN rv.name IS NULL THEN r.radar_version_name ELSE rv.name END AS radar_version_name,
+                           CASE WHEN rv.parent_id IS NULL THEN r.radar_version_parent_id ELSE rv.parent_id END AS radar_version_parent_id,
+                           ri.position AS actual_ring_position
                     FROM blip_event e
-                             JOIN r ON (r.parent_id = e.blip_event_id)
+                             JOIN r ON r.parent_id = e.blip_event_id
+                             LEFT JOIN radar_version rv ON e.blip_event_id = rv.blip_event_id
+                             LEFT JOIN ring ri ON e.ring_id = ri.ring_id
+                             LEFT JOIN quadrant q ON e.quadrant_id = q.quadrant_id
+                ), cte AS (
+                    SELECT *,
+                           LEAD(r.ring_id) OVER (PARTITION BY r.blip_id ORDER BY r.level) AS prev_ring_id,
+                           LEAD(r.quadrant_id) OVER (PARTITION BY r.blip_id ORDER BY r.level) AS prev_quadrant_id
+                    FROM r
                 )
-                SELECT blip_event_id, comment, parent_id, blip_id, quadrant_id, ring_id, author_id, radar_id, creation_time, last_change_time
-                FROM r
-                ORDER BY r.level DESC;
+                SELECT
+                    cte.blip_event_id, cte.comment, cte.parent_id, cte.blip_id, cte.quadrant_id, cte.ring_id,
+                    cte.author_id, cte.radar_id, cte.creation_time, cte.last_change_time, cte.radar_version_name AS radar_version,
+                    CASE
+                        WHEN cte.blip_id IS NULL THEN 'INITIAL'
+                        WHEN cte.ring_id IS NULL THEN 'DELETE'
+                        WHEN cte.quadrant_id != cte.prev_quadrant_id THEN 'SEC_MOVE'
+                        WHEN cte.ring_id = cte.prev_ring_id THEN 'FIXED'
+                        WHEN cte.prev_ring_id IS NULL THEN 'NEW'
+                        WHEN ri.position > cte.actual_ring_position THEN 'FORWARD'
+                        ELSE 'BACKWARD'
+                    END AS draw_info
+                FROM cte
+                         LEFT JOIN ring ri ON cte.prev_ring_id = ri.ring_id
+                ORDER BY cte.level DESC;
                 """
             , BlipEvent.class)
         .setParameter("blipEventId", blipEventId)

--- a/src/main/java/ru/hh/techradar/repository/CompanyRepository.java
+++ b/src/main/java/ru/hh/techradar/repository/CompanyRepository.java
@@ -1,8 +1,10 @@
 package ru.hh.techradar.repository;
 
+import java.util.List;
 import org.hibernate.SessionFactory;
 import org.springframework.stereotype.Repository;
 import ru.hh.techradar.entity.Company;
+import ru.hh.techradar.entity.User;
 
 @Repository
 public class CompanyRepository extends BaseRepositoryImpl<Long, Company> {
@@ -12,5 +14,14 @@ public class CompanyRepository extends BaseRepositoryImpl<Long, Company> {
   public CompanyRepository(SessionFactory sessionFactory) {
     super(sessionFactory, Company.class);
     this.sessionFactory = sessionFactory;
+  }
+
+  public List<User> findUsersByCompany(Long companyId) {
+    return sessionFactory.getCurrentSession()
+        .createQuery("""
+            SELECT c.users FROM Company c WHERE c.id = :companyId
+            """, User.class)
+        .setParameter("companyId", companyId)
+        .getResultList();
   }
 }

--- a/src/main/java/ru/hh/techradar/repository/RadarVersionRepository.java
+++ b/src/main/java/ru/hh/techradar/repository/RadarVersionRepository.java
@@ -18,6 +18,16 @@ public class RadarVersionRepository extends BaseRepositoryImpl<Long, RadarVersio
     this.sessionFactory = sessionFactory;
   }
 
+  @Override
+  public Optional<RadarVersion> findById(Long id) {
+    Session session = sessionFactory.openSession();
+    return session.createQuery("""
+            SELECT rv FROM RadarVersion rv LEFT JOIN FETCH rv.parent WHERE rv.id = :id
+            """, RadarVersion.class)
+        .setParameter("id", id)
+        .uniqueResultOptional();
+  }
+
   public Collection<RadarVersion> findAllByRadarId(Long radarId) {
     Session session = sessionFactory.openSession();
     return session.createQuery("SELECT rv FROM RadarVersion rv WHERE rv.radar.id = :radarId AND rv.parent IS NOT NULL", RadarVersion.class)

--- a/src/main/java/ru/hh/techradar/service/BlipEventService.java
+++ b/src/main/java/ru/hh/techradar/service/BlipEventService.java
@@ -23,7 +23,6 @@ public class BlipEventService {
   public static final String ROOT_BLIP_EVENT_COMMENT = "root blip event";
   public static final String NO_CORRESPONDING_RELEASE_VERSION_EXCEPTION_MESSAGE = "There's no corresponding release version!";
   public static final String DELETE_OPERATION_FOR_ROOT_BLIP_EVENT_IS_NOT_SUPPORTED = "Delete operation for root blip event is not supported";
-  private final BlipEventMapper blipEventMapper;
   private final BlipEventRepository blipEventRepository;
   private final BlipService blipService;
   private final QuadrantService quadrantService;
@@ -31,16 +30,16 @@ public class BlipEventService {
   private final UserService userService;
   private final RadarService radarService;
   private final RadarVersionRepository radarVersionRepository;
+  private final BlipEventMapper blipEventMapper;
 
   public BlipEventService(
-      BlipEventMapper blipEventMapper, BlipEventRepository blipEventRepository,
+      BlipEventRepository blipEventRepository,
       BlipService blipService,
       QuadrantService quadrantService,
       RingService ringService,
       UserService userService,
       RadarService radarService,
-      RadarVersionRepository radarVersionRepository) {
-    this.blipEventMapper = blipEventMapper;
+      RadarVersionRepository radarVersionRepository, BlipEventMapper blipEventMapper) {
     this.blipEventRepository = blipEventRepository;
     this.blipService = blipService;
     this.quadrantService = quadrantService;
@@ -48,6 +47,7 @@ public class BlipEventService {
     this.userService = userService;
     this.radarService = radarService;
     this.radarVersionRepository = radarVersionRepository;
+    this.blipEventMapper = blipEventMapper;
   }
 
   @Transactional
@@ -69,11 +69,11 @@ public class BlipEventService {
         .orElseThrow(() -> new NotFoundException(RadarVersion.class, radarVersionId));
     RadarVersion parentRadarVersion = radarVersionRepository.getParentRadarVersion(radarVersion)
         .orElseThrow(() -> new NotFoundException(RadarVersion.class, radarVersion.getParent().getId()));
-    if (!parentRadarVersion.getBlipEvent().getId()
+    if (parentRadarVersion.getBlipEvent().getId()
         .equals(radarVersion.getBlipEvent().getId())) {
-      return insert(dto, username);
+      return isolatedSave(dto, username);
     }
-    return isolatedSave(dto, username);
+    return insert(dto, username);
   }
 
   public BlipEvent prepareRootBlipEvent(User user, Radar radar) {
@@ -144,9 +144,13 @@ public class BlipEventService {
   }
 
   @Transactional(readOnly = true)
-  public List<BlipEvent> findAllBlipsByBlipEventId(Long blipEventId) {
-    BlipEvent validatedExistence = findById(blipEventId);
-    return blipEventRepository.findAllBlipEventsByBlipEventId(blipEventId);
+  public List<BlipEvent> findAllBlipsByRadarVersionId(Long radarVersionId) {
+    RadarVersion radarVersion = radarVersionRepository.findById(radarVersionId).orElseThrow(() -> new NotFoundException(
+        RadarVersion.class,
+        radarVersionId
+    ));
+    BlipEvent blipEvent = radarVersion.getBlipEvent();
+    return blipEventRepository.findAllBlipEventsByBlipEventId(blipEvent.getId());
   }
 
   @Transactional(readOnly = true)
@@ -179,29 +183,27 @@ public class BlipEventService {
   @Transactional
   public BlipEvent isolatedUpdate(BlipEventDto dto) {
     Long id = dto.getId();
-    BlipEvent found = blipEventRepository.findById(id).orElseThrow(() -> new NotFoundException(BlipEvent.class, id));
-    BlipEvent entity = fillBlipEventForUpdate(dto);
-    return blipEventRepository.update(blipEventMapper.toUpdate(found, entity));
+    BlipEvent target = blipEventRepository.findById(id).orElseThrow(() -> new NotFoundException(BlipEvent.class, id));
+    fillBlipEventForUpdate(target, dto);
+    return blipEventRepository.update(target);
   }
 
   private BlipEvent fillBlipEvent(BlipEventDto dto, String username) {
     BlipEvent blipEvent = blipEventMapper.toEntity(dto);
     Optional.ofNullable(dto.getParentId()).ifPresent(blipEvent::setParentId);
     blipEvent.setBlip(blipService.findById(dto.getBlipId()));
-    Optional.ofNullable(dto.getQuadrantId()).ifPresent(qId -> blipEvent.setQuadrant(quadrantService.findById(qId)));
-    Optional.ofNullable(dto.getRingId()).ifPresent(rId -> blipEvent.setRing(ringService.findById(rId)));
+    Optional.ofNullable(dto.getQuadrantId()).ifPresent(qId -> blipEvent.setQuadrant(qId.map(quadrantService::findById).orElse(null)));
+    Optional.ofNullable(dto.getRingId()).ifPresent(rId -> blipEvent.setRing(rId.map(ringService::findById).orElse(null)));
     blipEvent.setUser(userService.findByUsername(username));
     blipEvent.setRadar(radarService.findById(dto.getRadarId()));
     return blipEvent;
   }
 
-  private BlipEvent fillBlipEventForUpdate(BlipEventDto dto) {
-    BlipEvent blipEvent = blipEventMapper.toEntity(dto);
-    Optional.ofNullable(dto.getParentId()).ifPresent(blipEvent::setParentId);
-    Optional.ofNullable(dto.getBlipId()).ifPresent(bId -> blipEvent.setBlip(blipService.findById(bId)));
-    Optional.ofNullable(dto.getQuadrantId()).ifPresent(qId -> blipEvent.setQuadrant(quadrantService.findById(qId)));
-    Optional.ofNullable(dto.getRingId()).ifPresent(rId -> blipEvent.setRing(ringService.findById(rId)));
-    return blipEvent;
+  private void fillBlipEventForUpdate(BlipEvent target, BlipEventDto dto) {
+    Optional.ofNullable(dto.getParentId()).ifPresent(target::setParentId);
+    Optional.ofNullable(dto.getBlipId()).ifPresent(bId -> target.setBlip(blipService.findById(bId)));
+    Optional.ofNullable(dto.getQuadrantId()).ifPresent(qId -> target.setQuadrant(qId.map(quadrantService::findById).orElse(null)));
+    Optional.ofNullable(dto.getRingId()).ifPresent(rId -> target.setRing(rId.map(ringService::findById).orElse(null)));
   }
 
   @Transactional

--- a/src/main/java/ru/hh/techradar/service/CompanyService.java
+++ b/src/main/java/ru/hh/techradar/service/CompanyService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.hh.techradar.entity.Company;
+import ru.hh.techradar.entity.User;
 import ru.hh.techradar.exception.NotFoundException;
 import ru.hh.techradar.mapper.CompanyMapper;
 import ru.hh.techradar.repository.CompanyRepository;
@@ -53,5 +54,10 @@ public class CompanyService implements BaseService<Long, Company> {
   @Transactional(readOnly = true)
   public List<Company> findAll() {
     return companyRepository.findAll();
+  }
+
+  @Transactional(readOnly = true)
+  public List<User> findUsersByCompanyId(Long companyId) {
+    return companyRepository.findUsersByCompany(companyId);
   }
 }

--- a/src/main/java/ru/hh/techradar/service/RadarVersionService.java
+++ b/src/main/java/ru/hh/techradar/service/RadarVersionService.java
@@ -3,6 +3,7 @@ package ru.hh.techradar.service;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.hh.techradar.dto.RadarVersionDto;
@@ -147,7 +148,9 @@ public class RadarVersionService {
     updateReleaseAndToggle(dto, target);
     Optional.ofNullable(dto.getName()).ifPresent(target::setName);
     updateBlipEvent(dto, target);
-    return target;
+    RadarVersion updatedRadarVersion = radarVersionRepository.update(target);
+    Hibernate.initialize(updatedRadarVersion.getParent());
+    return updatedRadarVersion;
   }
 
   private void updateValidating(RadarVersionDto dto, RadarVersion target) {
@@ -197,6 +200,7 @@ public class RadarVersionService {
     radarVersionRepository.deleteById(id);
   }
 
+  @Transactional(readOnly = true)
   public Collection<RadarVersion> findAllReleasedRadarVersions(Long radarId) {
     return radarVersionRepository.findAllReleasedRadarVersions(radarId);
   }

--- a/src/main/java/ru/hh/techradar/service/UserService.java
+++ b/src/main/java/ru/hh/techradar/service/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
 
   @Transactional(readOnly = true)
   public Collection<User> findAllByFilter(UserFilter filter) {
-    return companyService.findById(filter.getCompanyId()).getUsers();
+    return companyService.findUsersByCompanyId(filter.getCompanyId());
   }
 
   @Transactional(readOnly = true)

--- a/src/main/resources/changelog/v001/230616-090012-add_columns_to_blip_event.xml
+++ b/src/main/resources/changelog/v001/230616-090012-add_columns_to_blip_event.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="230616-090012" author="parfenovds">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="blip_event"/>
+                <not>
+                    <columnExists tableName="blip_event" columnName="draw_info"/>
+                </not>
+                <not>
+                    <columnExists tableName="blip_event" columnName="radar_version"/>
+                </not>
+            </and>
+        </preConditions>
+        <addColumn tableName="blip_event">
+            <column name="draw_info"
+                    type="varchar(10)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="blip_event">
+            <column name="radar_version"
+                    type="varchar(50)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
1. Blip event improvement:
    add BlipEventShortReadDto and BlipEventShortReadMapper to have shortage output in some cases;
    improve update of blip event (add possibility to send null values for quadrantId and blipId in PUT with saving of possibility to send in PUT only fields needs to be updated);
    improve radar-log (add drawInfo and radar version name for every blip event in log).
2. Improve findActualBlipsByRadarVersionWithDrawInfo method: usage of subquery instead of radar version id and add logic for blip migration between different quadrants (SEC_MOVE status in drawInfo);
    Fix BlipDto (remove old parameter).
3. Improve radar versions (add parent name and corresponding methods).
4. Improve getting users linked to certain company.
